### PR TITLE
Avoid the ClassCastException

### DIFF
--- a/src/com/github/kumaraman21/intellijbehave/service/JBehaveUtil.java
+++ b/src/com/github/kumaraman21/intellijbehave/service/JBehaveUtil.java
@@ -170,8 +170,12 @@ public class JBehaveUtil {
 
     @NotNull
     private static Set<String> getAliasesAnnotationTexts(@NotNull PsiAnnotation aliasAnnotation) {
-        final PsiArrayInitializerMemberValue attrValue = (PsiArrayInitializerMemberValue) aliasAnnotation.findAttributeValue("values");
-
+        PsiArrayInitializerMemberValue attrValue = null;
+        try {
+            attrValue = (PsiArrayInitializerMemberValue) aliasAnnotation.findAttributeValue("values");
+        }catch(ClassCastException cce){
+            //swallow!
+        }
         if (attrValue == null) {
             return ImmutableSet.of();
         }


### PR DESCRIPTION
With this change I avoid the ClassCastException but it is not tested further since I use the plugin only for navigation from stories to the code.
