### PR TITLE
Step reference not being resolved for valid lines

### DIFF
--- a/src/main/java/com/github/kumaraman21/intellijbehave/service/JBehaveStepsIndex.java
+++ b/src/main/java/com/github/kumaraman21/intellijbehave/service/JBehaveStepsIndex.java
@@ -14,6 +14,7 @@ import com.intellij.openapi.module.Module;
 import com.intellij.openapi.module.ModuleUtilCore;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.roots.ProjectRootModificationTracker;
+import com.intellij.openapi.util.Key;
 import com.intellij.psi.PsiAnnotation;
 import com.intellij.psi.PsiClass;
 import com.intellij.psi.impl.java.stubs.index.JavaAnnotationIndex;
@@ -46,7 +47,7 @@ public final class JBehaveStepsIndex implements Disposable {
 
     @NotNull
     public Collection<JavaStepDefinition> findStepDefinitions(@NotNull JBehaveStep step) {
-        return ReadAction.compute(() -> CachedValuesManager.getCachedValue(step, (CachedValueProvider<? extends Collection<JavaStepDefinition>>) () -> {
+        return ReadAction.compute(() -> CachedValuesManager.getCachedValue(step, Key.create(step.getStepText()), (CachedValueProvider<? extends Collection<JavaStepDefinition>>) () -> {
             Module module = ModuleUtilCore.findModuleForPsiElement(step);
 
             if (module == null) {


### PR DESCRIPTION
This appear to be due to the cache key not being provided and therefore defaulting to the name of the CachedValueProviders class, which in this case is an anonymous class (lambda). Reading the docs on CachedValueProvider and CacheValue I get the impression that they are expected to represent single values, as such this looks to be a bug as all steps would have the same key?

Fixed by specifying the key as the story text

Before:

![Screenshot from 2025-06-27 13-53-29](https://github.com/user-attachments/assets/c3a173a3-0813-48f1-aa61-fa6cac024770)


After:

![image](https://github.com/user-attachments/assets/ef680c4c-cc08-46d5-af8d-7765812c0789)
